### PR TITLE
feat: persist state in local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# No Code HTML Builder
+
+A single-page web app that generates and iteratively refines HTML using a custom AI endpoint.
+
+## Usage
+
+Open `no_code_builder.html` in your browser, describe the page you want, and click **Generate**. Use **Continue**, **Coach**, and **Next Step** to expand or improve the page. Your progress is saved locally, so you can close the page and continue later.
+
+## Development
+
+The app relies on CDN-hosted libraries: Bootstrap, jQuery, animate.css, AOS, FontAwesome, and clipboard.js. No build step is required; simply open the HTML file.

--- a/no_code_builder.html
+++ b/no_code_builder.html
@@ -48,8 +48,8 @@
     <!-- FontAwesome icons -->
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css"
-      integrity="sha512-DxV+EoADOkOygM4IR9yXP8Sb2qwgidEmeqAEmDKIOfPRQZOWbXCzLC6vjbZyy0vPisbH2SyW27+ddLVCN+OMzQ=="
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
+      integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
@@ -226,13 +226,36 @@
          const nextStepBtn = document.getElementById('nextStepBtn');
          const doctorInput = document.getElementById('doctorInput');
          const doctorBtn = document.getElementById('doctorBtn');
-         const loadingSpinner = document.getElementById('loadingSpinner');
-         const previewFrame = document.getElementById('previewFrame');
-         // Keep track of conversation messages for multiple calls
-         let messages = [];
+        const loadingSpinner = document.getElementById('loadingSpinner');
+        const previewFrame = document.getElementById('previewFrame');
+        // Keep track of conversation messages for multiple calls
+        let messages = [];
         // History of page states for undo/redo (each entry stores {html, messages})
         let history = [];
         let historyIndex = -1;
+        const STORAGE_KEY = 'ncbState';
+
+        function loadState() {
+          const raw = localStorage.getItem(STORAGE_KEY);
+          if (!raw) return;
+          try {
+            const saved = JSON.parse(raw);
+            if (saved.html) {
+              previewFrame.srcdoc = saved.html;
+              updateUiFromHtml(saved.html);
+            }
+            if (Array.isArray(saved.messages)) {
+              messages = saved.messages.map((m) => ({ role: m.role, content: m.content }));
+            }
+            history = [
+              { html: previewFrame.srcdoc, messages: messages.map((m) => ({ role: m.role, content: m.content })) }
+            ];
+            historyIndex = 0;
+            updateUndoRedoButtons();
+          } catch (err) {
+            console.error('Failed to load saved state', err);
+          }
+        }
 
          async function sendRequest(messageList) {
            const payload = {
@@ -263,6 +286,7 @@
            messages = [];
            history = [];
            historyIndex = -1;
+           localStorage.removeItem(STORAGE_KEY);
            updateUndoRedoButtons();
            // Show loading spinner
            loadingSpinner.style.display = 'block';
@@ -603,6 +627,14 @@
           history.push({ html: htmlSnapshot, messages: msgCopy });
           historyIndex = history.length - 1;
           updateUndoRedoButtons();
+          try {
+            localStorage.setItem(
+              STORAGE_KEY,
+              JSON.stringify({ html: htmlSnapshot, messages: msgCopy })
+            );
+          } catch (err) {
+            console.error('Failed to persist state', err);
+          }
         }
 
         // Update Undo/Redo buttons based on current history index
@@ -635,6 +667,11 @@
             $('#previewFrame').css('opacity', 0).animate({ opacity: 1 }, 400);
             updateUiFromHtml(state.html);
             updateUndoRedoButtons();
+            try {
+              localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+            } catch (err) {
+              console.error('Failed to persist state', err);
+            }
           }
         }
 
@@ -648,6 +685,11 @@
             $('#previewFrame').css('opacity', 0).animate({ opacity: 1 }, 400);
             updateUiFromHtml(state.html);
             updateUndoRedoButtons();
+            try {
+              localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+            } catch (err) {
+              console.error('Failed to persist state', err);
+            }
           }
         }
 
@@ -767,6 +809,7 @@
         doctorBtn.addEventListener('click', applyDoctor);
         nextStepBtn.addEventListener('click', nextStep);
         // Initialize undo/redo buttons state
+        loadState();
         updateUndoRedoButtons();
         undoBtn.addEventListener('click', undo);
         redoBtn.addEventListener('click', redo);


### PR DESCRIPTION
## Summary
- persist generated HTML and AI messages in localStorage to resume sessions
- update FontAwesome CDN to v7.0.1
- document usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a59c44088321a855602f992f9fa8