### PR TITLE
feat: merge AI patches into existing DOM

### DIFF
--- a/no_code_builder.html
+++ b/no_code_builder.html
@@ -257,10 +257,11 @@
           }
         }
 
-         async function sendRequest(messageList) {
+        async function sendRequest(messageList) {
            const payload = {
              maxTokens: 16384,
              messages: messageList,
+             html: previewFrame.srcdoc,
            };
            const response = await fetch(
              'https://ominisender.com/wp-json/azurechat/v1/completions',
@@ -520,6 +521,24 @@
           }
         }
 
+        function mergeHtmlIntoPreview(newHtml) {
+          const parser = new DOMParser();
+          const incomingDoc = parser.parseFromString(newHtml, 'text/html');
+          const doc = previewFrame.contentDocument;
+          if (!doc) {
+            return previewFrame.srcdoc;
+          }
+          Array.from(incomingDoc.head.children).forEach((node) => {
+            doc.head.appendChild(doc.importNode(node, true));
+          });
+          Array.from(incomingDoc.body.children).forEach((node) => {
+            doc.body.appendChild(doc.importNode(node, true));
+          });
+          const merged = doc.documentElement.outerHTML;
+          previewFrame.srcdoc = merged;
+          return merged;
+        }
+
         // Apply an individual suggestion by sending it to the assistant
         async function applySuggestion(suggestion) {
           if (!suggestion || suggestion.trim().length === 0) {
@@ -547,9 +566,9 @@
             }
             // Save assistant message
             messages.push({ role: 'assistant', content: html });
-            previewFrame.srcdoc = html;
+            const mergedHtml = mergeHtmlIntoPreview(html);
             $('#previewFrame').css('opacity', 0).animate({ opacity: 1 }, 600);
-            const hasContent = html && html.trim().length > 0;
+            const hasContent = mergedHtml && mergedHtml.trim().length > 0;
             copyBtn.disabled = !hasContent;
             exportBtn.disabled = !hasContent;
             continueBtn.disabled = !hasContent;
@@ -557,7 +576,7 @@
             nextStepBtn.disabled = !hasContent;
             // Save current state for undo/redo
             if (hasContent) {
-              saveState(html, messages);
+              saveState(mergedHtml, messages);
             }
           } catch (err) {
             console.error(err);
@@ -594,11 +613,11 @@
               html = data.choices[0].message.content;
             }
             messages.push({ role: 'assistant', content: html });
-            previewFrame.srcdoc = html;
+            const mergedHtml = mergeHtmlIntoPreview(html);
             $('#previewFrame').css('opacity', 0).animate({ opacity: 1 }, 600);
             // Clear doctor input
             doctorInput.value = '';
-            const hasContent = html && html.trim().length > 0;
+            const hasContent = mergedHtml && mergedHtml.trim().length > 0;
             copyBtn.disabled = !hasContent;
             exportBtn.disabled = !hasContent;
             continueBtn.disabled = !hasContent;
@@ -606,7 +625,7 @@
             nextStepBtn.disabled = !hasContent;
             // Save current state for undo/redo
             if (hasContent) {
-              saveState(html, messages);
+              saveState(mergedHtml, messages);
             }
           } catch (err) {
             console.error(err);


### PR DESCRIPTION
## Summary
- include iframe HTML in requests so AI sees current context
- merge AI HTML patches into existing DOM via DOMParser
- persist merged HTML in undo/redo history

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a8d60fbc832183b8dc43c174f66f