### PR TITLE
feat: merge continued HTML via DOM diff

### DIFF
--- a/no_code_builder.html
+++ b/no_code_builder.html
@@ -374,10 +374,30 @@
              ) {
                html = data.choices[0].message.content;
              }
-             // Append continuation to preview by concatenating
-             previewFrame.srcdoc += html;
-             // Save assistant message to conversation
-             messages.push({ role: 'assistant', content: html });
+            // Merge continuation into preview by diffing DOMs
+            const parser = new DOMParser();
+            const existingDoc = parser.parseFromString(
+              previewFrame.srcdoc || '',
+              'text/html'
+            );
+            const newDoc = parser.parseFromString(html, 'text/html');
+            ['head', 'body'].forEach((section) => {
+              const existingSection = existingDoc[section];
+              const newSection = newDoc[section];
+              if (existingSection && newSection) {
+                Array.from(newSection.childNodes).forEach((node) => {
+                  const isDuplicate = Array.from(existingSection.childNodes).some(
+                    (existingNode) => existingNode.isEqualNode(node)
+                  );
+                  if (!isDuplicate) {
+                    existingSection.appendChild(node.cloneNode(true));
+                  }
+                });
+              }
+            });
+            previewFrame.srcdoc = existingDoc.documentElement.outerHTML;
+            // Save assistant message to conversation
+            messages.push({ role: 'assistant', content: html });
              // Fade in preview again
              $('#previewFrame')
                .css('opacity', 0)


### PR DESCRIPTION
## Summary
- merge continued HTML output into preview via DOM diff to avoid duplicates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ae1e0598832187910e33785bdcd0