### PR TITLE
test: add unsupported input tests

### DIFF
--- a/__tests__/validateSections.test.js
+++ b/__tests__/validateSections.test.js
@@ -5,9 +5,9 @@ const { spawnSync } = require('child_process');
 
 const script = path.resolve(__dirname, '..', 'validateSections.js');
 
-function runValidate(html) {
-  const tmpFile = path.join(os.tmpdir(), `validate-${Date.now()}-${Math.random()}.html`);
-  fs.writeFileSync(tmpFile, html);
+function runValidate(content) {
+  const tmpFile = path.join(os.tmpdir(), `validate-${Date.now()}-${Math.random()}`);
+  fs.writeFileSync(tmpFile, content);
   const result = spawnSync('node', [script, tmpFile], { encoding: 'utf8' });
   fs.unlinkSync(tmpFile);
   return result;
@@ -25,4 +25,25 @@ test('fails when a top-level block is missing data-section', () => {
   const result = runValidate(html);
   expect(result.status).not.toBe(0);
   expect(result.stderr).toContain('missing data-section');
+});
+
+test('fails for binary file input', () => {
+  const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  const result = runValidate(binary);
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('Unsupported');
+});
+
+test('fails for JSON text input', () => {
+  const json = '{"foo":"bar"}';
+  const result = runValidate(json);
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('Unsupported');
+});
+
+test('fails when the path is unreadable', () => {
+  const missingPath = path.join(os.tmpdir(), 'missing-file.html');
+  const result = spawnSync('node', [script, missingPath], { encoding: 'utf8' });
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('Unable to read file');
 });

--- a/validateSections.js
+++ b/validateSections.js
@@ -16,6 +16,12 @@ try {
   process.exit(1);
 }
 
+const trimmed = html.trimStart();
+if (!trimmed.startsWith('<')) {
+  console.error('Unsupported input format: expected HTML.');
+  process.exit(1);
+}
+
 const $ = cheerio.load(html);
 let missing = false;
 $('body').children().each((index, element) => {


### PR DESCRIPTION
## Summary
- fail validation when input isn't HTML
- add tests for binary, JSON, and missing paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e5f1bc788321842551cb58526ece