### PR TITLE
feat: modularize AI provider, persist history, and add section editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A single-page web app that generates and iteratively refines HTML using a custom
 
 Open `no_code_builder.html` in your browser, describe the page you want, and click **Generate**. When describing new blocks, include `data-section="<unique-name>"` on the wrapper element for each logical block. If duplicates slip in, the app automatically suffixes them (e.g. `hero` → `hero-1`) and shows a warning so each block remains unique. Use **Continue**, **Coach**, and **Next Step** to expand or improve the page. The **Edit** button opens an embedded code editor (Ace) so you can adjust the HTML manually. AI-powered changes merge with existing markup rather than replacing it, and your progress is saved locally, so you can close the page and continue later.
 
+Right‑click any generated block with a `data-section` attribute to open a context menu for editing or deleting that specific section. Conversation history and page revisions are versioned and stored in `localStorage` so sessions survive reloads and future schema changes.
+
 
 ## Development
 

--- a/no_code_builder.html
+++ b/no_code_builder.html
@@ -258,6 +258,7 @@
       referrerpolicy="no-referrer"
     ></script>
     <!-- Removed anime.js: using jQuery for simple fade animations -->
+    <script src="src/ai/providers/azure.js"></script>
 
     <script>
       // Initialize AOS once the document is ready
@@ -287,24 +288,128 @@
          const undoBtn = document.getElementById('undoBtn');
          const redoBtn = document.getElementById('redoBtn');
          const copyBtn = document.getElementById('copyBtn');
-         const exportBtn = document.getElementById('exportBtn');
-         const editBtn = document.getElementById('editBtn');
-         const saveEditBtn = document.getElementById('saveEditBtn');
-         const coachBtn = document.getElementById('coachBtn');
-         const suggestionsList = document.getElementById('suggestionsList');
-         const nextStepBtn = document.getElementById('nextStepBtn');
-         const doctorInput = document.getElementById('doctorInput');
-         const doctorBtn = document.getElementById('doctorBtn');
-        const sectionWarning = document.getElementById('sectionWarning');
-        const loadingSpinner = document.getElementById('loadingSpinner');
-        const previewFrame = document.getElementById('previewFrame');
-        let editor;
-        // Keep track of conversation messages for multiple calls
-        let messages = [];
-        // History of page states for undo/redo (each entry stores {html, messages})
-        let history = [];
-        let historyIndex = -1;
+        const exportBtn = document.getElementById('exportBtn');
+        const editBtn = document.getElementById('editBtn');
+        const saveEditBtn = document.getElementById('saveEditBtn');
+        const coachBtn = document.getElementById('coachBtn');
+        const suggestionsList = document.getElementById('suggestionsList');
+        const nextStepBtn = document.getElementById('nextStepBtn');
+        const doctorInput = document.getElementById('doctorInput');
+        const doctorBtn = document.getElementById('doctorBtn');
+       const sectionWarning = document.getElementById('sectionWarning');
+       const loadingSpinner = document.getElementById('loadingSpinner');
+       const previewFrame = document.getElementById('previewFrame');
+       let editor;
+       // Keep track of conversation messages for multiple calls
+       let messages = [];
+       // History of page states for undo/redo (each entry stores {html, messages})
+       let history = [];
+       let historyIndex = -1;
         const STORAGE_KEY = 'ncbState';
+        const STORAGE_VERSION = 1;
+        const aiProvider = window.aiProviders && window.aiProviders.azure;
+
+        const sectionMenu = document.createElement('div');
+        sectionMenu.id = 'sectionContextMenu';
+        sectionMenu.className = 'dropdown-menu';
+        const editItem = document.createElement('button');
+        editItem.className = 'dropdown-item';
+        editItem.textContent = 'Edit Section';
+        const deleteItem = document.createElement('button');
+        deleteItem.className = 'dropdown-item';
+        deleteItem.textContent = 'Delete Section';
+        sectionMenu.appendChild(editItem);
+        sectionMenu.appendChild(deleteItem);
+        document.body.appendChild(sectionMenu);
+        let currentSection = null;
+
+        function persistHistory() {
+          try {
+            localStorage.setItem(
+              STORAGE_KEY,
+              JSON.stringify({ version: STORAGE_VERSION, history, index: historyIndex })
+            );
+          } catch (err) {
+            console.error('Failed to persist state', err);
+          }
+        }
+
+        function showSectionMenu(x, y, section) {
+          currentSection = section;
+          sectionMenu.style.left = x + 'px';
+          sectionMenu.style.top = y + 'px';
+          sectionMenu.classList.add('show');
+        }
+
+        function hideSectionMenu() {
+          sectionMenu.classList.remove('show');
+          currentSection = null;
+        }
+
+        previewFrame.addEventListener('load', function () {
+          const doc = previewFrame.contentDocument;
+          if (!doc) return;
+          doc.addEventListener('contextmenu', function (e) {
+            const section = e.target.closest('[data-section]');
+            if (section) {
+              e.preventDefault();
+              const rect = previewFrame.getBoundingClientRect();
+              showSectionMenu(rect.left + e.clientX, rect.top + e.clientY, section);
+            }
+          });
+        });
+
+        document.addEventListener('click', hideSectionMenu);
+
+        editItem.addEventListener('click', async function () {
+          hideSectionMenu();
+          if (!currentSection) return;
+          const instructions = prompt('Describe how to edit this section:');
+          if (!instructions || !aiProvider) return;
+          try {
+            const userMsg = instructions + '\n\nHTML:\n' + currentSection.outerHTML;
+            const payload = {
+              maxTokens: 2048,
+              messages: [
+                { role: 'system', content: 'Update the given HTML section according to user instructions and return only HTML.' },
+                { role: 'user', content: userMsg },
+              ],
+            };
+            const data = await aiProvider.send(payload);
+            let newHtml = '';
+            if (typeof data === 'string') newHtml = data;
+            else if (data.html) newHtml = data.html;
+            else if (data.content) newHtml = data.content;
+            else if (data.choices && data.choices[0] && data.choices[0].message)
+              newHtml = data.choices[0].message.content;
+            messages.push({ role: 'user', content: userMsg });
+            messages.push({ role: 'assistant', content: newHtml });
+            const wrapper = document.createElement('div');
+            wrapper.innerHTML = newHtml.trim();
+            const replacement = wrapper.firstElementChild;
+            if (replacement) {
+              currentSection.replaceWith(replacement);
+              previewFrame.srcdoc = previewFrame.contentDocument.documentElement.outerHTML;
+              validateDataSections();
+              const updatedHtml = previewFrame.srcdoc;
+              updateUiFromHtml(updatedHtml);
+              saveState(updatedHtml, messages);
+            }
+          } catch (err) {
+            alert('Edit failed: ' + err.message);
+          }
+        });
+
+        deleteItem.addEventListener('click', function () {
+          hideSectionMenu();
+          if (!currentSection) return;
+          currentSection.remove();
+          previewFrame.srcdoc = previewFrame.contentDocument.documentElement.outerHTML;
+          validateDataSections();
+          const updatedHtml = previewFrame.srcdoc;
+          updateUiFromHtml(updatedHtml);
+          saveState(updatedHtml, messages);
+        });
 
         function validateDataSections() {
           const doc = previewFrame.contentDocument;
@@ -351,19 +456,19 @@
           if (!raw) return;
           try {
             const saved = JSON.parse(raw);
-            if (saved.html) {
-              previewFrame.srcdoc = saved.html;
+            if (saved.version !== STORAGE_VERSION) return;
+            if (Array.isArray(saved.history) && saved.history.length) {
+              history = saved.history;
+              historyIndex = typeof saved.index === 'number' ? saved.index : history.length - 1;
+              const state = history[historyIndex];
+              previewFrame.srcdoc = state.html || '';
               validateDataSections();
               const sanitized = previewFrame.srcdoc;
               updateUiFromHtml(sanitized);
+              if (Array.isArray(state.messages)) {
+                messages = state.messages.map((m) => ({ role: m.role, content: m.content }));
+              }
             }
-            if (Array.isArray(saved.messages)) {
-              messages = saved.messages.map((m) => ({ role: m.role, content: m.content }));
-            }
-            history = [
-              { html: previewFrame.srcdoc, messages: messages.map((m) => ({ role: m.role, content: m.content })) }
-            ];
-            historyIndex = 0;
             updateUndoRedoButtons();
           } catch (err) {
             console.error('Failed to load saved state', err);
@@ -371,23 +476,15 @@
         }
 
         async function sendRequest(messageList) {
+          if (!aiProvider) {
+            throw new Error('AI provider not configured');
+          }
           const payload = {
             maxTokens: 16384,
             messages: messageList,
             html: previewFrame.srcdoc,
           };
-          const response = await fetch(
-            'https://ominisender.com/wp-json/azurechat/v1/completions',
-            {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(payload),
-            }
-          );
-          if (!response.ok) {
-            throw new Error('Server responded with status ' + response.status);
-          }
-          return response.json();
+          return aiProvider.send(payload);
         }
 
         function mergeHtml(currentHtml, newHtml) {
@@ -658,18 +755,10 @@
                 },
               ],
             };
-            const response = await fetch(
-              'https://ominisender.com/wp-json/azurechat/v1/completions',
-              {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-              }
-            );
-            if (!response.ok) {
-              throw new Error('Server responded with status ' + response.status);
+            if (!aiProvider) {
+              throw new Error('AI provider not configured');
             }
-            const data = await response.json();
+            const data = await aiProvider.send(payload);
             let suggestionsText = '';
             if (data && typeof data === 'string') {
               suggestionsText = data;
@@ -872,14 +961,7 @@
           history.push({ html: htmlSnapshot, messages: msgCopy });
           historyIndex = history.length - 1;
           updateUndoRedoButtons();
-          try {
-            localStorage.setItem(
-              STORAGE_KEY,
-              JSON.stringify({ html: htmlSnapshot, messages: msgCopy })
-            );
-          } catch (err) {
-            console.error('Failed to persist state', err);
-          }
+          persistHistory();
         }
 
         // Update Undo/Redo buttons based on current history index
@@ -915,11 +997,7 @@
             $('#previewFrame').css('opacity', 0).animate({ opacity: 1 }, 400);
             updateUiFromHtml(updated);
             updateUndoRedoButtons();
-            try {
-              localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-            } catch (err) {
-              console.error('Failed to persist state', err);
-            }
+            persistHistory();
           }
         }
 
@@ -935,11 +1013,7 @@
             $('#previewFrame').css('opacity', 0).animate({ opacity: 1 }, 400);
             updateUiFromHtml(updated);
             updateUndoRedoButtons();
-            try {
-              localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-            } catch (err) {
-              console.error('Failed to persist state', err);
-            }
+            persistHistory();
           }
         }
 
@@ -971,18 +1045,10 @@
                 },
               ],
             };
-            const response = await fetch(
-              'https://ominisender.com/wp-json/azurechat/v1/completions',
-              {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-              }
-            );
-            if (!response.ok) {
-              throw new Error('Server responded with status ' + response.status);
+            if (!aiProvider) {
+              throw new Error('AI provider not configured');
             }
-            const data = await response.json();
+            const data = await aiProvider.send(payload);
             let suggestionsText = '';
             if (data && typeof data === 'string') {
               suggestionsText = data;

--- a/src/ai/providers/azure.js
+++ b/src/ai/providers/azure.js
@@ -1,0 +1,18 @@
+(function (global) {
+  const ENDPOINT = 'https://ominisender.com/wp-json/azurechat/v1/completions';
+
+  async function send(payload) {
+    const response = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      throw new Error('Server responded with status ' + response.status);
+    }
+    return response.json();
+  }
+
+  global.aiProviders = global.aiProviders || {};
+  global.aiProviders.azure = { send };
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- introduce pluggable Azure AI provider and replace inline fetch logic
- versioned localStorage keeps full conversation/history
- add context menu to edit or delete individual `data-section` blocks

## Testing
- `npm test`
- `npm run lint`
- `node scripts/check-cdn.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7f33285548321b9e2d1d53628935a