### PR TITLE
Hide loading spinner initially

### DIFF
--- a/no_code_builder.html
+++ b/no_code_builder.html
@@ -122,7 +122,7 @@
          </button>
        </div>
       <!-- [L125] Loading Spinner -->
-      <div id="loadingSpinner" class="text-center my-3">
+      <div id="loadingSpinner" class="text-center my-3" style="display: none;">
         <div class="spinner-border text-primary" role="status">
           <span class="visually-hidden">Loading...</span>
         </div>


### PR DESCRIPTION
## Summary
- Hide loading spinner by default so page loads without showing a spinner.
- Keep existing JavaScript logic to toggle spinner visibility during generation.

## Testing
- `npm test`
- `npm run validate`
- `npm run lint`
- `npm run check-cdn`


------
https://chatgpt.com/codex/tasks/task_e_68b7fe0d05948321bff10ff8de97a51d