### PR TITLE
chore: guard AOS init

### DIFF
--- a/no_code_builder.html
+++ b/no_code_builder.html
@@ -263,7 +263,9 @@
     <script>
       // Initialize AOS once the document is ready
       document.addEventListener('DOMContentLoaded', function () {
-        AOS.init({ duration: 600, once: true });
+        if (window.AOS) {
+          window.AOS.init({ duration: 600, once: true });
+        }
       });
 
       // ClipboardJS setup


### PR DESCRIPTION
## Summary
- avoid ReferenceError by checking for `window.AOS` before initialization

## Testing
- `npm test`
- `npm run lint`
- `npm run validate`
- `npm run check-cdn`


------
https://chatgpt.com/codex/tasks/task_e_68b8003b17148321838470189c3788a3