### PR TITLE
Handle aborted requests in Azure provider

### DIFF
--- a/no_code_builder.html
+++ b/no_code_builder.html
@@ -660,12 +660,16 @@
            if (hasContent) {
              saveState(sanitizedHtml, messages);
            }
-           } catch (err) {
-             console.error(err);
-             alert('An error occurred: ' + err.message);
-           } finally {
-             loadingSpinner.style.display = 'none';
-           }
+          } catch (err) {
+            if (err.name === 'AbortError') {
+              console.warn('Request aborted');
+            } else {
+              console.error(err);
+              alert('An error occurred: ' + err.message);
+            }
+          } finally {
+            loadingSpinner.style.display = 'none';
+          }
          }
 
          async function continueHtml() {
@@ -712,12 +716,16 @@
              if (hasContent) {
                saveState(mergedHtml, messages);
              }
-           } catch (err) {
-             console.error(err);
-             alert('An error occurred: ' + err.message);
-           } finally {
-             loadingSpinner.style.display = 'none';
-           }
+          } catch (err) {
+            if (err.name === 'AbortError') {
+              console.warn('Request aborted');
+            } else {
+              console.error(err);
+              alert('An error occurred: ' + err.message);
+            }
+          } finally {
+            loadingSpinner.style.display = 'none';
+          }
          }
 
         function exportHtml() {
@@ -825,8 +833,12 @@
               });
             }
           } catch (err) {
-            console.error(err);
-            alert('An error occurred: ' + err.message);
+            if (err.name === 'AbortError') {
+              console.warn('Request aborted');
+            } else {
+              console.error(err);
+              alert('An error occurred: ' + err.message);
+            }
           } finally {
             coachBtn.disabled = false;
             // Enable next step if there are suggestions to act upon
@@ -889,8 +901,12 @@
               messages.pop();
             }
           } catch (err) {
-            console.error(err);
-            alert('An error occurred: ' + err.message);
+            if (err.name === 'AbortError') {
+              console.warn('Request aborted');
+            } else {
+              console.error(err);
+              alert('An error occurred: ' + err.message);
+            }
           } finally {
             loadingSpinner.style.display = 'none';
           }
@@ -954,8 +970,12 @@
               messages.pop();
             }
           } catch (err) {
-            console.error(err);
-            alert('An error occurred: ' + err.message);
+            if (err.name === 'AbortError') {
+              console.warn('Request aborted');
+            } else {
+              console.error(err);
+              alert('An error occurred: ' + err.message);
+            }
           } finally {
             loadingSpinner.style.display = 'none';
           }
@@ -1119,8 +1139,12 @@
               }
             }
           } catch (err) {
-            console.error(err);
-            alert('An error occurred: ' + err.message);
+            if (err.name === 'AbortError') {
+              console.warn('Request aborted');
+            } else {
+              console.error(err);
+              alert('An error occurred: ' + err.message);
+            }
           } finally {
             // Re-enable next step if we still have content
             const hasContentNow = previewFrame.srcdoc && previewFrame.srcdoc.trim().length > 0;

--- a/src/ai/providers/azure.js
+++ b/src/ai/providers/azure.js
@@ -2,15 +2,27 @@
   const ENDPOINT = 'https://ominisender.com/wp-json/azurechat/v1/completions';
 
   async function send(payload) {
-    const response = await fetch(ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (!response.ok) {
-      throw new Error('Server responded with status ' + response.status);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15000);
+    try {
+      const response = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error('Server responded with status ' + response.status);
+      }
+      return response.json();
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        throw new Error('Request timed out');
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutId);
     }
-    return response.json();
   }
 
   global.aiProviders = global.aiProviders || {};


### PR DESCRIPTION
## Summary
- add 15s timeout using AbortController for Azure provider requests
- handle aborted requests in UI and hide spinner

## Testing
- `npm test`
- `npm run lint`
- `npm run validate`
- `npm run check-cdn`


------
https://chatgpt.com/codex/tasks/task_e_68b805b12c648321b0c28fb9f7a54bda